### PR TITLE
CH-02 챌린지 취소 API 구현

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/_challenge/controller/ChallengeController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/_challenge/controller/ChallengeController.java
@@ -1,0 +1,25 @@
+package com.github.thirty_day_challenge.domain._challenge.controller;
+
+import com.github.thirty_day_challenge.domain._challenge.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/users/challenges")
+@RequiredArgsConstructor
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @DeleteMapping("/{challengeId}/cancel")
+    public ResponseEntity<Void> cancelChallenge(@PathVariable UUID challengeId) {
+        challengeService.cancelChallenge(challengeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/_challenge/dto/response/SimpleChallengeResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/_challenge/dto/response/SimpleChallengeResponse.java
@@ -1,0 +1,25 @@
+package com.github.thirty_day_challenge.domain._challenge.dto.response;
+
+
+import com.github.thirty_day_challenge.domain._challenge.entity.Challenge;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@Builder
+
+public class SimpleChallengeResponse {
+
+    UUID id;
+
+    String name;
+
+    LocalDate startedAt;
+
+    LocalDate endedAt;
+
+    Challenge.ChallengeStatus status;
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/_challenge/entity/Challenge.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/_challenge/entity/Challenge.java
@@ -1,0 +1,64 @@
+package com.github.thirty_day_challenge.domain._challenge.entity;
+
+import com.github.thirty_day_challenge.domain._challenge.dto.response.SimpleChallengeResponse;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Challenge {
+
+    @Id
+    private UUID id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String name;
+
+    private String description;
+
+    private String code;
+
+    private LocalDate startedAt;
+
+    private LocalDate endedAt;
+
+    private Integer limit;
+
+    private ChallengeStatus status;
+
+    public void cancel() {
+        this.status = ChallengeStatus.CANCEL;
+    }
+
+    public enum ChallengeStatus {
+        ACTIVE,
+        COMPLETED,
+        CANCEL
+    }
+
+    public static SimpleChallengeResponse from(Challenge challenge) {
+        return SimpleChallengeResponse.builder()
+                .id(challenge.getId())
+                .name(challenge.getName())
+                .startedAt(challenge.getStartedAt())
+                .endedAt(challenge.getEndedAt())
+                .status(challenge.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/_challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/_challenge/repository/ChallengeRepository.java
@@ -1,0 +1,9 @@
+package com.github.thirty_day_challenge.domain._challenge.repository;
+
+import com.github.thirty_day_challenge.domain._challenge.entity.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, UUID> {
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/_challenge/service/ChallengeService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/_challenge/service/ChallengeService.java
@@ -1,0 +1,26 @@
+package com.github.thirty_day_challenge.domain._challenge.service;
+
+import com.github.thirty_day_challenge.domain._challenge.entity.Challenge;
+import com.github.thirty_day_challenge.domain._challenge.repository.ChallengeRepository;
+import io.swagger.v3.oas.annotations.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+
+    public void cancelChallenge(UUID challengeId) {
+
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 챌린지를 찾을 수 없습니다."));
+
+        challenge.cancel();
+
+        challengeRepository.save(challenge);
+    }
+}


### PR DESCRIPTION
- Challenge 엔티티에 cancel() 메서드 추가 -> 상태 CANCEL로 변경
- ChallengeService: cancelChallenge(UUID challengeId) 메서드 구현
- ChallengeController: @DeleteMapping("/{challengeId}/cancel") 추가
- ChallengeRepository로 챌린지 조회 후 상태 변경/저장 처리