### PR TITLE
[CH-15] 본인 전체 랭킹 조회 구현

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
@@ -6,6 +6,7 @@ import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,6 +29,7 @@ public class RankController {
     private final RankService rankService;
 
     @GetMapping("/{challenge}/rank/me")
+    @Operation(description = "각 챌린지 내 본인 스트릭 조회")
     public ResponseEntity<DailyRecordResponse> getMyStreak(
             @CurrentUser User user,
             @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge
@@ -37,9 +39,11 @@ public class RankController {
     }
 
     @GetMapping("/rank/me")
+    @Operation(description = "본인의 각 챌린지 스트릭 랭킹 조회")
     public ResponseEntity<List<DailyRecordResponse>> getMyRank(
             @CurrentUser User user
     ) {
+
         return ResponseEntity.ok(rankService.getMyRank(user));
     }
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
@@ -40,6 +40,7 @@ public class RankService {
     }
 
     public List<DailyRecordResponse> getMyRank(User user) {
+
         return userChallengeRepository.findByUser(user).stream()
                 .map(userChallenge -> getMyStreak(user, userChallenge.getChallenge()))
                 .sorted(Comparator.comparingInt(DailyRecordResponse::getStreak).reversed())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 로그인한 사용자가 참여 중인 각 챌린지의 연속 기록과 개인 랭크를 한눈에 조회하는 API가 추가되었습니다. 결과는 연속 기록이 높은 순으로 정렬되어 반환됩니다.
* 문서
  * 해당 엔드포인트와 기존 본인 스트릭 조회에 대한 API 설명이 API 문서(스웨거)에 추가되어 사용 가이드가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->