### PR TITLE
CH-16 챌린지 내 참여자 순위 조회 구현

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
@@ -4,6 +4,7 @@ import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge._rank.service.RankService;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._user_challenge.dto.UserChallengeRankResponse;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,4 +47,12 @@ public class RankController {
 
         return ResponseEntity.ok(rankService.getMyRank(user));
     }
+
+    @GetMapping("/{challenge}/rank")
+    public ResponseEntity<UserChallengeRankResponse> getRank(
+            @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge
+    ) {
+        return ResponseEntity.ok(rankService.getRank(challenge));
+    }
+
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
@@ -4,6 +4,7 @@ import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge._rank.service.RankService;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.StreakResponse;
+import com.github.thirty_day_challenge.domain.user._user_challenge.dto.UserChallengeRankResponse;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,9 +49,11 @@ public class RankController {
     }
 
     @GetMapping("/{challenge}/rank")
+    @Operation(description = "챌린지 내 참여자 순위 조회")
     public ResponseEntity<UserChallengeRankResponse> getRank(
             @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge
     ) {
+
         return ResponseEntity.ok(rankService.getRank(challenge));
     }
 

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
@@ -1,6 +1,5 @@
 package com.github.thirty_day_challenge.domain.user._challenge._rank.service;
 
-import com.github.thirty_day_challenge.domain.user._challenge.dto.response.SimpleChallengeResponse;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.StreakResponse;
@@ -41,7 +40,7 @@ public class RankService {
             streak++;
         }
 
-        return StreakResponse.from(challenge, streak);
+        return StreakResponse.from(user, challenge, streak);
     }
 
     public List<StreakResponse> getMyRank(User user) {
@@ -55,20 +54,21 @@ public class RankService {
     public UserChallengeRankResponse getRank(Challenge challenge) {
 
         List<UserChallenge> userChallenges = userChallengeRepository.findByChallenge(challenge);
+
         List<ParticipantsResponse> participants = new ArrayList<>();
 
         for (UserChallenge uc : userChallenges) {
+
             int streak = getMyStreak(uc.getUser(), challenge).getStreak();
 
-            ParticipantsResponse participant = ParticipantsResponse.of(uc, streak);
+            ParticipantsResponse participant = ParticipantsResponse.from(uc.getUser(), streak);
             participants.add(participant);
         }
 
-        participants.sort((p1, p2) -> p2.getStreak().compareTo(p1.getStreak()));
-
-        return UserChallengeRankResponse.of(
-                SimpleChallengeResponse.from(challenge),
-                participants
+        participants.sort(
+                (p1, p2) -> Integer.compare(p2.getStreak(), p1.getStreak())
         );
+
+        return UserChallengeRankResponse.from(challenge, participants);
     }
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
@@ -1,14 +1,19 @@
 package com.github.thirty_day_challenge.domain.user._challenge._rank.service;
 
+import com.github.thirty_day_challenge.domain.user._challenge.dto.response.SimpleChallengeResponse;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
+import com.github.thirty_day_challenge.domain.user._user_challenge.dto.ParticipantsResponse;
+import com.github.thirty_day_challenge.domain.user._user_challenge.dto.UserChallengeRankResponse;
+import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
 import com.github.thirty_day_challenge.domain.user._user_challenge.repository.UserChallengeRepository;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -45,5 +50,25 @@ public class RankService {
                 .map(userChallenge -> getMyStreak(user, userChallenge.getChallenge()))
                 .sorted(Comparator.comparingInt(DailyRecordResponse::getStreak).reversed())
                 .toList();
+    }
+
+    public UserChallengeRankResponse getRank(Challenge challenge) {
+
+        List<UserChallenge> userChallenges = userChallengeRepository.findByChallenge(challenge);
+        List<ParticipantsResponse> participants = new ArrayList<>();
+
+        for (UserChallenge uc : userChallenges) {
+            int streak = getMyStreak(uc.getUser(), challenge).getStreak();
+
+            ParticipantsResponse participant = ParticipantsResponse.of(uc, streak);
+            participants.add(participant);
+        }
+
+        participants.sort((p1, p2) -> p2.getStreak().compareTo(p1.getStreak()));
+
+        return UserChallengeRankResponse.of(
+                SimpleChallengeResponse.from(challenge),
+                participants
+        );
     }
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/StreakResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/StreakResponse.java
@@ -2,6 +2,8 @@ package com.github.thirty_day_challenge.domain.user._daily_record.dto.response;
 
 import com.github.thirty_day_challenge.domain.user._challenge.dto.response.SimpleChallengeResponse;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
+import com.github.thirty_day_challenge.domain.user.dto.response.SimpleUserResponse;
+import com.github.thirty_day_challenge.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,13 +13,16 @@ import lombok.Data;
 @AllArgsConstructor(staticName = "of")
 public class StreakResponse {
 
+    private SimpleUserResponse user;
+
     private SimpleChallengeResponse challenge;
 
     private Integer streak;
 
-    public static StreakResponse from(Challenge challenge, Integer streak) {
+    public static StreakResponse from(User user, Challenge challenge, Integer streak) {
 
         return StreakResponse.of(
+                SimpleUserResponse.from(user),
                 SimpleChallengeResponse.from(challenge),
                 streak
         );

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
@@ -1,7 +1,7 @@
 package com.github.thirty_day_challenge.domain.user._user_challenge.dto;
 
-import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
-import com.github.thirty_day_challenge.domain.user.dto.response.UserResponse;
+import com.github.thirty_day_challenge.domain.user.dto.response.SimpleUserResponse;
+import com.github.thirty_day_challenge.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,19 +9,14 @@ import lombok.Data;
 @AllArgsConstructor(staticName = "of")
 public class ParticipantsResponse {
 
-    UserResponse user;
-
-    boolean isOwner;
-
-    boolean isCompleted;
+    SimpleUserResponse user;
 
     int streak;
 
-    public static ParticipantsResponse of(UserChallenge userChallenge, int streak) {
+    public static ParticipantsResponse from(User user, int streak) {
+
         return ParticipantsResponse.of(
-                UserResponse.from(userChallenge.getUser()),
-                userChallenge.isOwner(),
-                userChallenge.isCompleted(),
+                SimpleUserResponse.from(user),
                 streak
         );
     }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
@@ -15,7 +15,7 @@ public class ParticipantsResponse {
 
     boolean isCompleted;
 
-    Integer streak;
+    int streak;
 
     public static ParticipantsResponse of(UserChallenge userChallenge, int streak) {
         return ParticipantsResponse.of(

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/ParticipantsResponse.java
@@ -1,0 +1,28 @@
+package com.github.thirty_day_challenge.domain.user._user_challenge.dto;
+
+import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
+import com.github.thirty_day_challenge.domain.user.dto.response.UserResponse;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+public class ParticipantsResponse {
+
+    UserResponse user;
+
+    boolean isOwner;
+
+    boolean isCompleted;
+
+    Integer streak;
+
+    public static ParticipantsResponse of(UserChallenge userChallenge, int streak) {
+        return ParticipantsResponse.of(
+                UserResponse.from(userChallenge.getUser()),
+                userChallenge.isOwner(),
+                userChallenge.isCompleted(),
+                streak
+        );
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/UserChallengeRankResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/UserChallengeRankResponse.java
@@ -1,0 +1,26 @@
+package com.github.thirty_day_challenge.domain.user._user_challenge.dto;
+
+import com.github.thirty_day_challenge.domain.user._challenge.dto.response.SimpleChallengeResponse;
+import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(description = "참여자 순위 응답 DTO")
+@AllArgsConstructor(staticName = "of")
+public class UserChallengeRankResponse {
+
+    private SimpleChallengeResponse challenge;
+
+    private List<ParticipantsResponse> participants;
+
+    public static UserChallengeRankResponse of(Challenge challenge, List<ParticipantsResponse> participants) {
+        return UserChallengeRankResponse.of(
+                SimpleChallengeResponse.from(challenge),
+                participants
+        );
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/UserChallengeRankResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/dto/UserChallengeRankResponse.java
@@ -17,7 +17,8 @@ public class UserChallengeRankResponse {
 
     private List<ParticipantsResponse> participants;
 
-    public static UserChallengeRankResponse of(Challenge challenge, List<ParticipantsResponse> participants) {
+    public static UserChallengeRankResponse from(Challenge challenge, List<ParticipantsResponse> participants) {
+
         return UserChallengeRankResponse.of(
                 SimpleChallengeResponse.from(challenge),
                 participants

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/repository/UserChallengeRepository.java
@@ -17,4 +17,6 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, UU
 
     @EntityGraph(attributePaths = {"user", "challenge"})
     Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
+
+    List<UserChallenge> findByChallenge(Challenge challenge);
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_user_challenge/repository/UserChallengeRepository.java
@@ -18,5 +18,6 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, UU
     @EntityGraph(attributePaths = {"user", "challenge"})
     Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
 
+    @EntityGraph(attributePaths = {"user"})
     List<UserChallenge> findByChallenge(Challenge challenge);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 특정 챌린지의 참여자 순위를 조회할 수 있는 공개 API를 추가했습니다 (GET /users/challenges/{challenge}/rank).
  - 참가자별 연속 달성일(streak)을 기준으로 정렬된 목록과 참가자 정보가 함께 반환됩니다.
  - 응답에 각 참가자의 간단한 사용자 정보와 챌린지 정보가 포함됩니다.

- 문서
  - 경로 변수에 대한 OpenAPI/Swagger 설명을 추가해 API 명세 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->