### PR TITLE
[CH-17] 일일 기록 목록 응답 API

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
@@ -3,7 +3,7 @@ package com.github.thirty_day_challenge.domain.user._challenge._rank.controller;
 import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge._rank.service.RankService;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.StreakResponse;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +30,7 @@ public class RankController {
 
     @GetMapping("/{challenge}/rank/me")
     @Operation(description = "각 챌린지 내 본인 스트릭 조회")
-    public ResponseEntity<DailyRecordResponse> getMyStreak(
+    public ResponseEntity<StreakResponse> getMyStreak(
             @CurrentUser User user,
             @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge
     ) {
@@ -40,7 +40,7 @@ public class RankController {
 
     @GetMapping("/rank/me")
     @Operation(description = "본인의 각 챌린지 스트릭 랭킹 조회")
-    public ResponseEntity<List<DailyRecordResponse>> getMyRank(
+    public ResponseEntity<List<StreakResponse>> getMyRank(
             @CurrentUser User user
     ) {
 

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
@@ -2,7 +2,7 @@ package com.github.thirty_day_challenge.domain.user._challenge._rank.service;
 
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.StreakResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._user_challenge.repository.UserChallengeRepository;
 import com.github.thirty_day_challenge.domain.user.entity.User;
@@ -18,7 +18,7 @@ public class RankService {
 
     private final UserChallengeRepository userChallengeRepository;
 
-    public DailyRecordResponse getMyStreak(User user, Challenge challenge) {
+    public StreakResponse getMyStreak(User user, Challenge challenge) {
 
         List<DailyRecord> dailyRecords = userChallengeRepository.findByUserAndChallenge(user, challenge)
                 .orElseThrow(ChallengeExceptions.USER_DONT_PARTICIPATE::toException)
@@ -36,14 +36,14 @@ public class RankService {
             streak++;
         }
 
-        return DailyRecordResponse.from(challenge, streak);
+        return StreakResponse.from(challenge, streak);
     }
 
-    public List<DailyRecordResponse> getMyRank(User user) {
+    public List<StreakResponse> getMyRank(User user) {
 
         return userChallengeRepository.findByUser(user).stream()
                 .map(userChallenge -> getMyStreak(user, userChallenge.getChallenge()))
-                .sorted(Comparator.comparingInt(DailyRecordResponse::getStreak).reversed())
+                .sorted(Comparator.comparingInt(StreakResponse::getStreak).reversed())
                 .toList();
     }
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
@@ -1,0 +1,41 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.controller;
+
+import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
+import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.service.DailyRecordService;
+import com.github.thirty_day_challenge.domain.user.entity.User;
+import com.github.thirty_day_challenge.global.util.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "기록")
+@Auth
+@Validated
+@RequestMapping("/users/challenges/{challenge}/records")
+@RestController
+@RequiredArgsConstructor
+public class DailyRecordController {
+
+    private final DailyRecordService dailyRecordService;
+
+    @GetMapping
+    @Operation(description = "캘린더 조회")
+    public ResponseEntity<ListDailyRecordResponse> getDailyRecords(
+            @CurrentUser User user,
+            @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge,
+            @Parameter(description = "연도") @RequestParam(required = false) Integer year,
+            @Parameter(description = "월") @RequestParam(required = false) @Min(1) @Max(12) Integer month
+    ) {
+
+        return ResponseEntity.ok(dailyRecordService.getDailyRecords(user, challenge, year, month));
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/ListDailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/ListDailyRecordResponse.java
@@ -1,0 +1,21 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(description = "일일 기록 목록 응답 DTO")
+@AllArgsConstructor(staticName = "of")
+public class ListDailyRecordResponse {
+
+    List<SimpleDailyRecordResponse> dailyRecords;
+
+    public static ListDailyRecordResponse from(List<DailyRecord> dailyRecords) {
+
+        return ListDailyRecordResponse.of(dailyRecords.stream().map(SimpleDailyRecordResponse::from).toList());
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/SimpleDailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/SimpleDailyRecordResponse.java
@@ -1,0 +1,30 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Schema(description = "일일 기록 응답 DTO")
+@AllArgsConstructor(staticName = "of")
+public class SimpleDailyRecordResponse {
+
+    UUID id;
+
+    LocalDateTime createdAt;
+
+    boolean isCompleted;
+
+    public static SimpleDailyRecordResponse from(DailyRecord record) {
+
+        return SimpleDailyRecordResponse.of(
+                record.getId(),
+                record.getCreatedAt(),
+                record.isCompleted()
+        );
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/StreakResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/StreakResponse.java
@@ -7,17 +7,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@Schema(description = "일일 기록 응답 DTO")
+@Schema(description = "스트릭 응답 DTO")
 @AllArgsConstructor(staticName = "of")
-public class DailyRecordResponse {
+public class StreakResponse {
 
     private SimpleChallengeResponse challenge;
 
     private Integer streak;
 
-    public static DailyRecordResponse from(Challenge challenge, Integer streak) {
+    public static StreakResponse from(Challenge challenge, Integer streak) {
 
-        return DailyRecordResponse.of(
+        return StreakResponse.of(
                 SimpleChallengeResponse.from(challenge),
                 streak
         );

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/repository/DailyRecordRepository.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/repository/DailyRecordRepository.java
@@ -1,0 +1,15 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.repository;
+
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
+import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DailyRecordRepository extends JpaRepository<DailyRecord, UUID> {
+
+    @Query("SELECT dr FROM DailyRecord dr WHERE dr.userChallenge = :userChallenge AND YEAR(dr.createdAt) = :year AND MONTH(dr.createdAt) = :month")
+    List<DailyRecord> findByUserChallengeAndYearAndMonth(UserChallenge userChallenge, Integer year, Integer month);
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
@@ -1,0 +1,27 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.service;
+
+import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
+import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.repository.DailyRecordRepository;
+import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
+import com.github.thirty_day_challenge.domain.user._user_challenge.repository.UserChallengeRepository;
+import com.github.thirty_day_challenge.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DailyRecordService {
+
+    private final UserChallengeRepository userChallengeRepository;
+    private final DailyRecordRepository dailyRecordRepository;
+
+    public ListDailyRecordResponse getDailyRecords(User user, Challenge challenge, Integer year, Integer month) {
+
+        UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge)
+                .orElseThrow(ChallengeExceptions.USER_DONT_PARTICIPATE::toException);
+
+        return ListDailyRecordResponse.from(dailyRecordRepository.findByUserChallengeAndYearAndMonth(userChallenge, year, month));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 특정 챌린지의 일일 기록을 조회하는 엔드포인트 추가. 연도(year)·월(month)로 필터링 가능하며, 인증된 사용자만 이용할 수 있습니다.
  - 잘못된 월 값(1~12 범위 외) 요청 시 400 응답으로 검증 강화.

- Refactor
  - 스트릭/랭크 API 응답 명칭을 Streak 기반으로 일관화하여 스키마를 명확히 정리했습니다. 클라이언트는 스트릭 값과 목록 응답을 보다 통일된 형태로 수신합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->