### PR TITLE
[CH-18] 기록 상세 조회 api 구현

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
@@ -2,7 +2,9 @@ package com.github.thirty_day_challenge.domain.user._daily_record.controller;
 
 import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._daily_record.service.DailyRecordService;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
@@ -38,4 +40,15 @@ public class DailyRecordController {
 
         return ResponseEntity.ok(dailyRecordService.getDailyRecords(user, challenge, year, month));
     }
+
+    @GetMapping("/{record}")
+    @Operation(description = "기록 상세 조회")
+    public ResponseEntity<DailyRecordResponse> getDailyRecord(
+            @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge,
+            @Parameter(description = "기록 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable DailyRecord record
+    ) {
+
+        return ResponseEntity.ok(dailyRecordService.getDailyRecord(challenge, record));
+    }
+
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/DailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/DailyRecordResponse.java
@@ -1,0 +1,33 @@
+package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Schema(description = "기록 상세 조회 DTO")
+@AllArgsConstructor(staticName = "of")
+public class DailyRecordResponse {
+
+    UUID id;
+
+    LocalDateTime createdAt;
+
+    boolean isCompleted;
+
+    String image;
+
+    public static DailyRecordResponse from(DailyRecord record) {
+
+        return DailyRecordResponse.of(
+                record.getId(),
+                record.getCreatedAt(),
+                record.isCompleted(),
+                record.getImage()
+        );
+    }
+}

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
@@ -2,7 +2,9 @@ package com.github.thirty_day_challenge.domain.user._daily_record.service;
 
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._daily_record.repository.DailyRecordRepository;
 import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
 import com.github.thirty_day_challenge.domain.user._user_challenge.repository.UserChallengeRepository;
@@ -23,5 +25,10 @@ public class DailyRecordService {
                 .orElseThrow(ChallengeExceptions.USER_DONT_PARTICIPATE::toException);
 
         return ListDailyRecordResponse.from(dailyRecordRepository.findByUserChallengeAndYearAndMonth(userChallenge, year, month));
+    }
+
+    public DailyRecordResponse getDailyRecord(Challenge challenge, DailyRecord dailyRecord) {
+
+        return DailyRecordResponse.from(dailyRecord);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 특정 챌린지의 특정 일일 기록 상세를 조회하는 GET API를 추가했습니다. 응답에는 기록 ID, 생성 시각, 완료 여부, 이미지가 포함됩니다.
- 문서
  - 신규 상세 조회 API에 대한 스웨거(OpenAPI) 문서를 추가해 요청/응답 스펙을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->