### PR TITLE
[CH-19] 기록 생성 api 구현

### DIFF
--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/controller/RankController.java
@@ -3,7 +3,7 @@ package com.github.thirty_day_challenge.domain.user._challenge._rank.controller;
 import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge._rank.service.RankService;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.StreakResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.StreakResponse;
 import com.github.thirty_day_challenge.domain.user.entity.User;
 import com.github.thirty_day_challenge.global.util.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_challenge/_rank/service/RankService.java
@@ -2,7 +2,7 @@ package com.github.thirty_day_challenge.domain.user._challenge._rank.service;
 
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.StreakResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.StreakResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._user_challenge.repository.UserChallengeRepository;
 import com.github.thirty_day_challenge.domain.user.entity.User;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/controller/DailyRecordController.java
@@ -2,8 +2,8 @@ package com.github.thirty_day_challenge.domain.user._daily_record.controller;
 
 import com.github.thirty_day_challenge.domain.auth.annotation.Auth;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.DailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.ListDailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._daily_record.service.DailyRecordService;
 import com.github.thirty_day_challenge.domain.user.entity.User;
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -49,6 +50,19 @@ public class DailyRecordController {
     ) {
 
         return ResponseEntity.ok(dailyRecordService.getDailyRecord(challenge, record));
+    }
+
+    @PostMapping("/submit")
+    @Operation(description = "기록 생성")
+    public ResponseEntity<Void> submitDailyRecord(
+            @CurrentUser User user,
+            @Parameter(description = "챌린지 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Challenge challenge,
+            @RequestBody @NotBlank String image
+    ) {
+
+        dailyRecordService.submitDailyRecord(user, challenge, image);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/DailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/DailyRecordResponse.java
@@ -1,4 +1,4 @@
-package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+package com.github.thirty_day_challenge.domain.user._daily_record.dto.response;
 
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/ListDailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/ListDailyRecordResponse.java
@@ -1,4 +1,4 @@
-package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+package com.github.thirty_day_challenge.domain.user._daily_record.dto.response;
 
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/SimpleDailyRecordResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/SimpleDailyRecordResponse.java
@@ -1,4 +1,4 @@
-package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+package com.github.thirty_day_challenge.domain.user._daily_record.dto.response;
 
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/StreakResponse.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/dto/response/StreakResponse.java
@@ -1,4 +1,4 @@
-package com.github.thirty_day_challenge.domain.user._daily_record.dto;
+package com.github.thirty_day_challenge.domain.user._daily_record.dto.response;
 
 import com.github.thirty_day_challenge.domain.user._challenge.dto.response.SimpleChallengeResponse;
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;

--- a/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
+++ b/src/main/java/com/github/thirty_day_challenge/domain/user/_daily_record/service/DailyRecordService.java
@@ -2,8 +2,8 @@ package com.github.thirty_day_challenge.domain.user._daily_record.service;
 
 import com.github.thirty_day_challenge.domain.user._challenge.entity.Challenge;
 import com.github.thirty_day_challenge.domain.user._challenge.exception.ChallengeExceptions;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.DailyRecordResponse;
-import com.github.thirty_day_challenge.domain.user._daily_record.dto.ListDailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.DailyRecordResponse;
+import com.github.thirty_day_challenge.domain.user._daily_record.dto.response.ListDailyRecordResponse;
 import com.github.thirty_day_challenge.domain.user._daily_record.entity.DailyRecord;
 import com.github.thirty_day_challenge.domain.user._daily_record.repository.DailyRecordRepository;
 import com.github.thirty_day_challenge.domain.user._user_challenge.entity.UserChallenge;
@@ -30,5 +30,17 @@ public class DailyRecordService {
     public DailyRecordResponse getDailyRecord(Challenge challenge, DailyRecord dailyRecord) {
 
         return DailyRecordResponse.from(dailyRecord);
+    }
+
+    public void submitDailyRecord(User user, Challenge challenge, String image) {
+
+        UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge)
+                .orElseThrow(ChallengeExceptions.USER_DONT_PARTICIPATE::toException);
+
+        dailyRecordRepository.save(DailyRecord.builder()
+                        .image(image)
+                        .isCompleted(true)
+                        .userChallenge(userChallenge)
+                        .build());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 일일 기록 제출 기능 추가: 사용자는 참여 중인 챌린지에 이미지(인증 샷)를 업로드해 당일 기록을 생성할 수 있습니다. 요청이 유효하면 200 OK를 반환합니다. 기존 조회·랭크·연속기록 기능은 그대로 동작합니다.
- 리팩터링
  - 응답 DTO 패키지 구조를 정리하여 모듈 경로를 일관성 있게 통합했습니다. 앱 동작이나 공개 API 계약에는 변화가 없으며 기존 클라이언트 사용에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->